### PR TITLE
Operator panel header spacing

### DIFF
--- a/components/g8ed/public/css/bind-all-overlay.css
+++ b/components/g8ed/public/css/bind-all-overlay.css
@@ -255,7 +255,7 @@
 .bind-all-operator-hostname {
     font-size: 13px;
     font-weight: 600;
-    color: var(--text-primary);
+    color: var(--text-muted);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/components/g8ed/public/css/operator-panel.css
+++ b/components/g8ed/public/css/operator-panel.css
@@ -486,7 +486,6 @@
   font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
   white-space: nowrap;
 }
 
@@ -913,7 +912,7 @@
 .operator-item-hostname {
   font-size: 13px;
   font-weight: 400;
-  color: var(--text-primary);
+  color: var(--text-muted);
   font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/components/g8ed/public/css/operator-panel.css
+++ b/components/g8ed/public/css/operator-panel.css
@@ -464,7 +464,7 @@
   border-bottom: 1px solid var(--border-color);
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   padding: 0 12px;
   box-sizing: border-box;
   width: 100%;


### PR DESCRIPTION
operator panel header spacing improved

<img width="400" height="265" alt="image" src="https://github.com/user-attachments/assets/7d888419-8106-480b-bc98-94d3e492a1b4" />
