### PR TITLE
warden doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ flowchart TD
 2. **Sage** writes an intent document — goals, constraints, success criteria — and hands it to the Tribunal.
 3. **The Tribunal** is five blind validators (Axiom, Concord, Variance, Pragma, Nemesis), each generating a candidate command independently with no visibility into the others. Two of five must converge for a winner. If not, an anonymized peer-review round runs.
 4. **The Auditor** reviews the winner with full memory access and may approve, swap, or revise. The Auditor is bonded 2–3× heavier than any Tribunal member and is itself peer-reviewed across conversations.
-5. **Warden** scans the approved command for risk — MITRE ATT&CK pattern matches, file/error blast radius, common destructive idioms.
+5. **Warden** (running on the Engine) scans the approved command for risk — MITRE ATT&CK pattern matches, file/error blast radius, and destructive idioms.
 6. **You** review the command and the risk assessment, and sign with a passkey, or you don't.
 7. **The Operator** receives the signed command over the outbound WebSocket, runs it in an isolated process group, captures the result into the local audit vault, and snapshots state into a git-backed ledger.
 
@@ -209,7 +209,8 @@ System fingerprint binding ties the Operator's mTLS cert to the host it was issu
 
 - **Auth** — FIDO2 / WebAuthn passkeys only. Passwords are unsupported by design.
 - **Transport** — TLS 1.3. Platform-generated ECDSA P-384 CA. Per-Operator mTLS client certs issued at claim time.
-- **Sentinel & Warden** — Pre-execution defensive analysis: command/error/file risk classifiers, MITRE-mapped detectors, double-pass scrubbing before any data reaches a model provider.
+- **Sentinel** — On-host defensive analysis: 46 MITRE-mapped detectors, 28 scrubbing patterns, and command allowlist/denylist enforcement.
+- **Warden** — Engine-side defensive coordination: command/error/file risk classifiers applied before human approval.
 - **Sessions** — Encrypted cookies, idle and absolute timeouts, IP tracking, timestamp + nonce replay protection.
 - **Sovereignty** — Raw command output never leaves the host. Only Sentinel-scrubbed metadata reaches model providers. Engine outage does not erase history.
 - **Compliance alignment** — NSA Zero Trust (exceeds requirements in 6 of 7 pillars), HIPAA-ready, FedRAMP-aligned controls.

--- a/docs/architecture/ai_agents.md
+++ b/docs/architecture/ai_agents.md
@@ -51,7 +51,7 @@ To prevent hallucinations and ensure safety, agents never write shell commands d
     - **Nemesis**: The "immune system" — produces plausible-but-flawed commands or honestly abstains.
 3. **Consensus & Tie-breaking**: Candidates are clustered by exact match. A winner is selected via ranked vote.
 4. **Auditor Review**: The **Auditor** judges the winning command against the intent. It can approve (`ok`), provide a `revised` command, or `swap` to a better dissenting cluster.
-5. **Warden Analysis**: The **Warden** sub-agents perform a final pre-execution risk assessment (Command, File, and Error risk).
+5. **Warden Analysis**: The **Warden** (running on the Engine) performs a pre-execution risk assessment (Command, File, and Error risk) using specialized sub-agents.
 6. **Human Approval**: The user reviews the command and risk assessment before execution on the Operator.
 
 ## Security & Governance

--- a/docs/architecture/position_paper.md
+++ b/docs/architecture/position_paper.md
@@ -38,7 +38,11 @@ The machine handles what is **machine-checkable**: internal consistency between 
 
 The human handles what is **only human-checkable**: intent fidelity at the deepest level — whether the action matches what they meant in their world, including unarticulated context — contextual stakes specific to their environment, acceptance of real-world consequences they alone will live with, implicit values the agent layer cannot access.
 
-Both signatures are required because the union of their competencies is what constitutes "safe to execute." Neither alone is sufficient. This is the architectural commitment from which everything else follows.
+This division of labor is expressed by the **Co-Validation Identity**:
+
+$$ \text{Safe}(a) \iff \sigma_{\text{machine}}(a) \wedge \sigma_{\text{human}}(a) $$
+
+Neither signature is sufficient alone; only the conjunction of both constitutes "safe to execute." This is the architectural commitment from which everything else follows.
 
 The economic implication is precise: **the User's time is not a free resource the system can spend at will. It is a stake the User contributes in exchange for the service only they can validate.** Every component upstream of human judgment exists to minimize what reaches the User, so that what does reach them is exclusively the human-domain question they alone can answer. This reframes the User's experience entirely. They are not babysitting an agent. They are providing the irreducible input the system structurally cannot generate.
 
@@ -52,28 +56,22 @@ There are three actors and two coupled systems.
 
 **The User** is the human who owns the infrastructure being operated. The User is external to both the Engine and the Operator. The Operator presents prompts to the User and receives the User's signature, but the User is not a sub-component of either system.
 
-```
-        ┌─────────────────────────┐
-        │       Engine            │
-        │  (stateless reasoner)   │
-        │                         │
-        │ Triage (interrogator) → │
-        │ Sage → Tribunal →       │
-        │ Auditor                 │
-        └────────────┬────────────┘
-                     │
-        intent + verdict + grounding
-                     │
-                     ▼
-        ┌─────────────────────────┐         ┌──────────────┐
-        │       Operator          │ ──prompt──▶│              │
-        │  (sovereign executor)   │         │     User     │
-        │                         │ ◀─approval──│   (human)    │
-        │  Warden → Exec → Audit  │         │              │
-        │       Vault + Git       │         └──────────────┘
-        └─────────────────────────┘
-                per-host,
-                local-first
+```mermaid
+graph TD
+    U[User]
+    subgraph Engine [The Engine]
+        T[Triage] --> S[Sage]
+        S --> Tr[Tribunal]
+        Tr --> Au[Auditor]
+        Au --> W[Warden]
+    end
+    subgraph Operator [The Operator]
+        Ex[Exec]
+        Ex --> Ad[Audit Vault]
+        Ad --> G[Git Ledger]
+    end
+    U[User] -- signature --> W
+    W -- co-validated command --> Ex
 ```
 
 The Engine is replaceable. The Operator is the system of record. This inversion is the architectural payload of the proposal: the AI layer can be swapped, audited, or revoked without losing history, because history lives on the host that owns the infrastructure being operated, not in the cloud where the AI runs.
@@ -87,6 +85,12 @@ The Engine implements a consensus mechanism in which AI personas are validators 
 ### The Vortex Principle
 
 The Engine's consensus is built on **tiered information quarantine**, which I call the Vortex Principle. Each agent operates in a sealed information environment, believing it is playing a smaller game than it is actually in. The interrogator does not know the planner exists. The planner does not know the auditor has cross-conversation memory. The validator panel does not know which member among them is the calibrated adversary. Only one role — the Auditor — has full visibility, and the Auditor is bonded most heavily and subject to peer review.
+
+The mathematical invariant of the Vortex is the **Independence of Validators**:
+
+$$ \forall p_i, p_j \in \text{Tribunal}, i \neq j: I(X_i ; X_j | \mathcal{V}) \approx 0 $$
+
+Where $I$ is mutual information between the information states $X$ of two personas given the Vortex structure $\mathcal{V}$.
 
 The Vortex is load-bearing. Each quarantined view eliminates the deviation strategies that would otherwise be profitable. Agents cannot coordinate to game the consensus because they cannot identify their counterparties. Agents cannot shape their output to fit a known downstream expectation because they cannot see the downstream. The information-theoretic structure is what makes the consensus produce honest votes. Collapsing any quarantine layer creates a profitable deviation. The Vortex is not a UX choice. It is the safety mechanism.
 
@@ -102,7 +106,17 @@ The consensus round is run by a five-member Tribunal of LLM-instantiated persona
 
 Each member emits a candidate command independently with no visibility into the others. Candidates are clustered by exact match and votes are tallied. A winner requires ≥2 of 5 supporting votes. If consensus is weak, members enter Round 2 with anonymized peer review and may converge or hold.
 
-The Nemesis is the most novel element. Rather than relying on an external red team, I embed a calibrated adversary inside the consensus pool, scored on a proper scoring rule: attacks on flawed consensus that the Auditor confirms earn large gains; abstentions on clean consensus earn small gains; false alarms and misses lose stake. The dominant strategy is honest calibration. The realized attack rate becomes a learned signal of actual flaw density in the honest four's output — adversarial pressure as continuous quality measurement.
+This is governed by the **Plurality Consensus Rule**:
+
+$$ \text{Consensus}(c) \iff |\{ p \in \text{Tribunal} : p(I) = c \}| \geq 2 $$
+
+The Nemesis is the most novel element. Rather than relying on an external red team, I embed a calibrated adversary inside the consensus pool, scored on a proper scoring rule: attacks on flawed consensus that the Auditor confirms earn large gains; abstentions on clean consensus earn small gains; false alarms and misses lose stake. The dominant strategy is honest calibration. 
+
+The **Nemesis Scoring Rule** is defined as:
+
+$$ S = \begin{cases} R_{hit} & \text{if } c_{nemesis} \text{ identifies a flaw confirmed by Auditor} \\ R_{abstain} & \text{if } c_{nemesis} = \emptyset \text{ and Tribunal is clean} \\ -R_{miss} & \text{if } c_{nemesis} = \emptyset \text{ and Tribunal is flawed} \\ -R_{false} & \text{if } c_{nemesis} \text{ proposes a flaw rejected by Auditor} \end{cases} $$
+
+The realized attack rate becomes a learned signal of actual flaw density in the honest four's output — adversarial pressure as continuous quality measurement.
 
 ### The Auditor and the User
 
@@ -158,11 +172,15 @@ For Cloud Operators on AWS, the Operator implements Zero Standing Privileges via
 
 This is the architectural complement to the Engine's intent articulation. The planner produces an intent. The Tribunal translates intent into a command. The Operator attaches the minimum IAM policy mapped to that intent.
 
+The **Temporal Privilege Function** ensures zero standing privileges:
+
+$$ P(t) = \begin{cases} P_{\text{base}} \cup P_{\text{intent}} & t \in [t_{\text{start}}, t_{\text{end}}] \\ P_{\text{base}} & t \notin [t_{\text{start}}, t_{\text{end}}] \end{cases} $$
+
 The result: no human and no AI agent ever needs to hold privileged AWS credentials at rest. Privileges are attached just-in-time, scoped to the intent, and revoked on completion. A compromise of any layer — the User's session, the Engine's reasoning state, the Operator's binary — cannot exfiltrate persistent credentials, because no persistent credentials exist.
 
 ### The Warden
 
-The Operator runs the Warden, a defensive coordinator that performs pre-execution risk assessment locally. The Warden classifies command risk (low/medium/high), file operation risk (factoring in Git state — operations that lose history are higher risk than reversible ones), and analyzes failures for auto-fix safety. The Warden's classifications populate the User's approval prompt with concrete risk indicators, making the User's co-validation more efficient.
+The Engine runs the Warden, a defensive coordinator that performs pre-execution risk assessment. The Warden classifies command risk (low/medium/high), file operation risk (factoring in Git state — operations that lose history are higher risk than reversible ones), and analyzes failures for auto-fix safety. The Warden's classifications populate the User's approval prompt with concrete risk indicators, making the User's co-validation more efficient.
 
 The Warden fails closed. Ambiguous risk is classified high. The Warden cannot lower a classification produced by deterministic pattern filters — `rm -rf /` is high regardless of AI judgment. The User is presented with the highest classification any layer produced.
 
@@ -180,7 +198,7 @@ Round 1 votes: Concord, Variance, and Pragma cluster on the manifest-first versi
 
 **The Auditor** reviews. It sees Sage's intent, the winning candidate, the dissenting clusters with their persona signatures, and pulls cross-conversation memory: *"This User had an incident last month involving wrong-directory deletion."* The Auditor verifies the manifest-first design matches the intent's caution and grounds the verdict in the precedent. The Nemesis attack is logged as a confirmed flaw caught — Nemesis's stake increases. The verdict is cryptographically committed to the reputation ledger.
 
-**The Operator** receives the verdict over mTLS WebSocket. The **Warden** runs locally: command risk medium (mass deletion), file operation risk medium-high (operations on a directory containing audit-relevant files, even with the exclusion), error risk classified as escalate-on-failure. The Operator prepares the JIT IAM scope: it attaches the `Log-Management` intent policy to its role, granting read access to `/var/log/db/` and write access for the manifest path.
+**The Operator receives the verdict over mTLS WebSocket.** The **Warden** (running on the Engine) has already classified the risk: command risk medium (mass deletion), file operation risk medium-high (operations on a directory containing audit-relevant files, even with the exclusion), error risk classified as escalate-on-failure. The Operator prepares the JIT IAM scope: it attaches the `Log-Management` intent policy to its role, granting read access to `/var/log/db/` and write access for the manifest path.
 
 **The Operator presents to the User**: the proposed command, the manifest path, the Auditor's grounding (*"matches your stated caution; cross-references prior incident"*), the Warden's risk classifications, and an expandable view of the Nemesis dissent (*"a candidate without manifest-first was rejected — here's why"*).
 

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -75,7 +75,8 @@ Host Filesystem / AWS / Target System
 | **g8ed → g8es** | Internal Docker network, `X-Internal-Auth` token (strictly enforced by g8es/g8eo in `--listen` mode) |
 | **g8ee → LLM (AI)** | Sentinel ingress scrubbing — a redundant layer of protection for all user messages and terminal output before they are transmitted to any model provider; raw output, credentials, and PII are replaced with safe placeholders |
 | **g8ed → g8eo** | WebSocket over mTLS (TLS 1.3), per-operator client certificate issued during device registration or bootstrap, platform CA fetched from hub at operator startup |
-| **Operator → Host** | Sentinel pre-execution threat blocking (46 MITRE-mapped detectors), egress data scrubbing (stdout/stderr), command allowlist/denylist, Human-in-the-Loop approval required for every state change |
+| **Operator → Host** | Sentinel pre-execution threat blocking (46 MITRE-mapped detectors), egress data scrubbing (stdout/stderr), and command allowlist/denylist enforcement. |
+| **Engine → User** | Warden risk assessment (Command, File, Error risk) presented for Human-in-the-Loop approval before command dispatch to Operator. |
 | **Data at Rest (g8es)** | SQLite at `0600` filesystem permissions (4 tables: documents, kv_store, sse_events, blobs); session fields encrypted at application layer by g8ed before persistence; **bootstrap secrets (`internal_auth_token`, `session_encryption_key`, `auditor_hmac_key`) persisted on the `g8es-ssl` volume and mirrored into the `platform_settings` document for consistency** |
 | **Data at Rest (LFAA Vaults)** | AES-256-GCM field-level encryption (content, stdout, stderr); DEK envelope encryption; KEK derived on-demand from operator API key via HKDF-SHA256 |
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes introduced by this PR -->

Warden and Sentinel were being conflated in the docs

## Engineering Commitment Checklist
- [x] User Intent is the Guiding Principle: Human control is maintained.
- [x] Human Agency is the Governance Model: AI proposes, human approves.
- [x] Security and Privacy as Bedrock: Changes pass the Security Review Checklist.
- [x] No Tech Debt: No `ensure*()`, `getOrCreate*()`, `JSON.stringify` as type coercion, `Any` in signatures, or `map[string]interface{}`.
- [x] Data Sovereignty: Stateless relay principles followed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code quality improvement, no logic changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [ ] I have reproduced the bug (if applicable) with a test before fixing it.
- [ ] I have added/updated tests to cover the changes.
- [x] All tests pass locally using `./g8e test <component>`.

## Related Documentation
- [x] I have reviewed and updated relevant documentation in `docs/` as necessary.
