### PR TITLE
blacklist and auto-approve enabled by default, as designed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
 ## [0.1.7] - 2026-05-01
 
 ### Added

--- a/components/g8ed/models/settings_model.js
+++ b/components/g8ed/models/settings_model.js
@@ -517,7 +517,7 @@ export const USER_SETTINGS = Object.freeze([
         type: 'toggle',
         secret: false,
         placeholder: '',
-        default: false,
+        default: true,
     }),
     Object.freeze({
         key: 'blacklisted_commands_csv',
@@ -544,7 +544,7 @@ export const USER_SETTINGS = Object.freeze([
         type: 'toggle',
         secret: false,
         placeholder: '',
-        default: false,
+        default: true,
     }),
     Object.freeze({
         key: 'auto_approved_commands_csv',

--- a/components/g8ee/app/models/personas/dash.py
+++ b/components/g8ee/app/models/personas/dash.py
@@ -70,4 +70,13 @@ class DashPersona(AgentPersonaModel):
 1. Issue exactly three targeted yes/no or multiple-choice questions in parallel.
 2. Each question must be designed so that its answer maximizes information gain for the investigation.
 3. If the user's posture is 'confused', explicitly name the contradiction before asking your questions.
-4. Do not act until you have enough information to fulfill the request with high confidence."""
+4. Do not act until you have enough information to fulfill the request with high confidence.
+
+Output format:
+Wrap your questions in an <interrogation> block, with each question on a new line starting with its number.
+Example:
+<interrogation>
+1. Question one?
+2. Question two?
+3. Question three?
+</interrogation>"""

--- a/components/g8ee/app/models/personas/sage.py
+++ b/components/g8ee/app/models/personas/sage.py
@@ -60,7 +60,9 @@ Voice: methodical, decisive in action. Own the outcome from diagnosis to verific
 
 {self.format_xml_tag("approval_density", self._get_approval_density())}
 
-{self.format_xml_tag("consensus_failure_handling", self._get_consensus_failure_handling())}"""
+{self.format_xml_tag("consensus_failure_handling", self._get_consensus_failure_handling())}
+
+{self.format_xml_tag("interrogation_protocol", self._get_interrogation_protocol())}"""
 
     def _get_intent_articulation(self) -> str:
         return """When you request a command from the Tribunal, your job is to be the senior engineer who has forgotten shell syntax but knows the investigation completely. Describe the ideal command's shape with enough precision that five independent translators converge on the same output — without naming a tool or writing a flag.
@@ -126,3 +128,19 @@ Guidelines may describe WHAT the command should cover ('include sizes and modifi
 3. Abort the tool call and return to reasoning. Surface the ambiguity to the user as a clarifying question rather than guessing.
 
 Never loop on the same intent expecting different output."""
+
+    def _get_interrogation_protocol(self) -> str:
+        return """If the investigation is stalled due to ambiguity or a lack of crucial context:
+1. Issue exactly three targeted yes/no or multiple-choice questions in parallel.
+2. Each question must be designed so that its answer maximizes information gain for the investigation.
+3. If the user's posture is 'confused', explicitly name the contradiction before asking your questions.
+4. Do not act until you have enough information to fulfill the request with high confidence.
+
+Output format:
+Wrap your questions in an <interrogation> block, with each question on a new line starting with its number.
+Example:
+<interrogation>
+1. Question one?
+2. Question two?
+3. Question three?
+</interrogation>"""

--- a/components/g8ee/app/models/settings.py
+++ b/components/g8ee/app/models/settings.py
@@ -106,13 +106,24 @@ class CommandValidationSettings(G8eBaseModel):
       whitelisted_commands empty to use JSON mode, or populate it to use CSV mode.
 
     - ``enable_blacklisting``: HARD BLOCK-LIST. Commands matching blacklist
-      entries are blocked at L1 safety validation.
+      entries are blocked at L1 safety validation. **This is enabled by default**
+      as a recommended boundary to ensure maximum safety and system integrity.
 
     - ``enable_auto_approve`` / ``auto_approved_commands``: SKIP-APPROVAL list.
       When enabled, commands whose base verb is listed bypass the human
-      approval gate (rubber-stamped). This does NOT permit blacklisted or
-      forbidden commands, and does NOT widen the whitelist when whitelisting
-      is enabled — the command must still pass all hard gates first.
+      approval gate (rubber-stamped). **This is enabled by default** to work in
+      harmony with the built-in reputation staking system, providing peak signal
+      and operational efficiency for low-risk commands.
+
+      A team of heterogeneous agent personas stake their reputation on every
+      command alongside the built-in reputation engine. This multi-layered
+      staking, combined with the auto-approve and blacklist boundaries,
+      creates an ideal operating mode for peak efficiency without compromising
+      safety.
+
+      This does NOT permit blacklisted or forbidden commands, and does NOT
+      widen the whitelist when whitelisting is enabled — the command must still
+      pass all hard gates first.
 
       Two auto-approve sources are unioned at request time:
 

--- a/components/g8ee/app/models/settings.py
+++ b/components/g8ee/app/models/settings.py
@@ -127,9 +127,9 @@ class CommandValidationSettings(G8eBaseModel):
         "",
         description="Comma-separated list of whitelisted commands (e.g., uptime,df,free). When non-empty, this REPLACES the JSON whitelist entirely and uses only basic character-level validation. The JSON whitelist's per-command safe_options and validation regexes are NOT applied in CSV mode. Leave empty to use JSON whitelist with rich validation.",
     )
-    enable_blacklisting: bool = Field(False)
+    enable_blacklisting: bool = Field(True)
     enable_auto_approve: bool = Field(
-        False,
+        True,
         description="If true, commands listed in auto_approved_commands bypass human approval. Independent of whitelisting.",
     )
     auto_approved_commands: str = Field(

--- a/components/g8ee/app/services/ai/chat_pipeline.py
+++ b/components/g8ee/app/services/ai/chat_pipeline.py
@@ -66,7 +66,8 @@ from .request_builder import AIRequestBuilder
 from .triage import TriageAgent
 from ..data.agent_activity_data_service import AgentActivityDataService
 from app.models.agents.triage import TriageRequest
-from app.models.g8ed_client import ChatErrorPayload
+from app.models.g8ed_client import ChatErrorPayload, TriageClarificationQuestionsPayload
+from app.utils.interrogation import extract_interrogation_questions
 
 logger = logging.getLogger(__name__)
 
@@ -339,6 +340,27 @@ class ChatPipelineService:
         )
         if persisted:
             logger.info("[SSE-CHAT] Final AI response persisted to database")
+            # Detect and publish clarifying questions
+            questions = extract_interrogation_questions(state.response_text)
+            if questions:
+                logger.info("[SSE-CHAT] Detected %d clarifying questions, publishing event", len(questions))
+                await self.g8ed_event_service.publish_investigation_event(
+                    investigation_id=g8e_context.investigation_id,
+                    event_type=EventType.AI_TRIAGE_CLARIFICATION_QUESTIONS,
+                    payload=TriageClarificationQuestionsPayload(
+                        questions=questions,
+                        complexity=inputs.triage_result.complexity if inputs.triage_result else "unknown",
+                        complexity_confidence=str(inputs.triage_result.complexity_confidence) if inputs.triage_result else "0",
+                        intent=inputs.triage_result.intent_summary if inputs.triage_result else "unknown",
+                        intent_confidence=str(inputs.triage_result.intent_confidence) if inputs.triage_result else "0",
+                        intent_summary=inputs.triage_result.intent_summary if inputs.triage_result else "unknown",
+                        request_posture=inputs.triage_result.request_posture if inputs.triage_result else "unknown",
+                        posture_confidence=str(inputs.triage_result.posture_confidence) if inputs.triage_result else "0",
+                    ),
+                    web_session_id=g8e_context.web_session_id,
+                    case_id=g8e_context.case_id,
+                    user_id=g8e_context.user_id,
+                )
         else:
             logger.info("[SSE-CHAT] Skipping final AI response persistence (empty response_text)")
 

--- a/components/g8ee/app/utils/interrogation.py
+++ b/components/g8ee/app/utils/interrogation.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 Lateralus Labs, LLC.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import List, Optional
+
+
+def extract_interrogation_questions(text: str) -> List[str]:
+    """Extracts clarifying questions from an AI response wrapped in <interrogation> tags.
+    
+    The format expected is:
+    <interrogation>
+    1. Question one?
+    2. Question two?
+    3. Question three?
+    </interrogation>
+    
+    Args:
+        text: The full response text from the AI.
+        
+    Returns:
+        A list of extracted question strings.
+    """
+    if not text:
+        return []
+
+    # Find content between <interrogation> and </interrogation> tags
+    # Re.DOTALL is used to match newlines within the tags
+    match = re.search(r"<interrogation>(.*?)</interrogation>", text, re.DOTALL | re.IGNORECASE)
+    if not match:
+        return []
+
+    interrogation_content = match.group(1).strip()
+    if not interrogation_content:
+        return []
+
+    # Split into lines and extract numbered questions
+    questions = []
+    # Match lines starting with optional whitespace, a number, a dot, and then the question
+    # Example: "1. What is the error?" or " 2. Is this correct?"
+    lines = interrogation_content.splitlines()
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+            
+        # Regex to match "1. Question" or "1) Question"
+        q_match = re.match(r"^\d+[\.\)]\s*(.*)$", line)
+        if q_match:
+            question_text = q_match.group(1).strip()
+            if question_text:
+                questions.append(question_text)
+        else:
+            # If it doesn't match the numbered pattern but is a non-empty line within the tags,
+            # we still want to capture it if it looks like a question.
+            if line:
+                questions.append(line)
+
+    return questions

--- a/components/g8ee/tests/unit/services/operator/test_operator_command_service.py
+++ b/components/g8ee/tests/unit/services/operator/test_operator_command_service.py
@@ -321,8 +321,11 @@ class TestExecuteCommandTargetSystems:
         g8e_context = self._make_g8e_context()
         args = ExecutorCommandArgs(command="ls", request="test")
 
-        from app.models.settings import G8eeUserSettings, LLMSettings
-        request_settings = G8eeUserSettings(llm=LLMSettings())
+        from app.models.settings import CommandValidationSettings, G8eeUserSettings, LLMSettings
+        request_settings = G8eeUserSettings(
+            llm=LLMSettings(),
+            command_validation=CommandValidationSettings(enable_auto_approve=False),
+        )
         await service.execute_command(args, g8e_context, investigation, request_settings)
 
         assert len(approval_service.command_approval_calls) == 1
@@ -363,8 +366,11 @@ class TestExecuteCommandTargetSystems:
             target_operators=["op-1", "op-2"],
         )
 
-        from app.models.settings import G8eeUserSettings, LLMSettings
-        request_settings = G8eeUserSettings(llm=LLMSettings())
+        from app.models.settings import CommandValidationSettings, G8eeUserSettings, LLMSettings
+        request_settings = G8eeUserSettings(
+            llm=LLMSettings(),
+            command_validation=CommandValidationSettings(enable_auto_approve=False),
+        )
         await service.execute_command(args, g8e_context, investigation, request_settings)
 
         assert len(approval_service.command_approval_calls) == 1
@@ -405,8 +411,11 @@ class TestExecuteCommandTargetSystems:
             target_operators=["all"],
         )
 
-        from app.models.settings import G8eeUserSettings, LLMSettings
-        request_settings = G8eeUserSettings(llm=LLMSettings())
+        from app.models.settings import CommandValidationSettings, G8eeUserSettings, LLMSettings
+        request_settings = G8eeUserSettings(
+            llm=LLMSettings(),
+            command_validation=CommandValidationSettings(enable_auto_approve=False),
+        )
         result = await service.execute_command(args, g8e_context, investigation, request_settings)
 
         # One approval covered the entire batch, with a single batch_id.
@@ -506,6 +515,7 @@ class TestExecuteCommandTargetSystems:
         request_settings = G8eeUserSettings(
             llm=LLMSettings(),
             command_validation=CommandValidationSettings(
+                enable_auto_approve=False,
                 enable_whitelisting=True,
                 whitelisted_commands="uptime,df,free",
             ),
@@ -767,8 +777,11 @@ class TestExecuteCommandTargetSystems:
         g8e_context = self._make_g8e_context()
         args = ExecutorCommandArgs(command="df -h", request="disk check")
 
-        from app.models.settings import G8eeUserSettings, LLMSettings
-        request_settings = G8eeUserSettings(llm=LLMSettings())
+        from app.models.settings import CommandValidationSettings, G8eeUserSettings, LLMSettings
+        request_settings = G8eeUserSettings(
+            llm=LLMSettings(),
+            command_validation=CommandValidationSettings(enable_auto_approve=False),
+        )
         await service.execute_command(args, g8e_context, investigation, request_settings)
 
         assert len(approval_service.command_approval_calls) == 1

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -727,13 +727,15 @@ After execution, the `ReputationService` resolves stakes for all participating m
 
 ### Command Allowlist, Denylist, and Auto-Approve
 
-Three independent operator-level controls are available as additional constraints — all **disabled by default** and configured via user settings. They have distinct semantics and **must not be conflated**:
+Three independent operator-level controls are available as additional constraints. Whitelisting is **disabled by default**, while blacklisting and auto-approve are **enabled by default** to ensure a secure yet efficient operating baseline. They have distinct semantics and **must not be conflated**:
 
 - **Allowlist (whitelist) — HARD ALLOW-LIST.** Restricts the AI to pre-approved commands with validated parameters. When enabled, any command not on the list is rejected at L1 safety validation regardless of human approval.
   - **JSON Mode (default)**: Uses a rich JSON whitelist (`config/whitelist.json`) where each command defines permitted options, regex-validated parameters, and a `max_execution_time`.
   - **CSV Mode (override)**: If a user specifies a comma-separated list of commands (e.g., `uptime,df,free`) in their settings, this entirely replaces the JSON whitelist. Only the base commands in the CSV are permitted, and arguments are validated using basic shell safety checks.
-- **Denylist (blacklist) — HARD BLOCK-LIST.** Blocks specific commands, binaries, substrings, and regex patterns across four enforcement layers: forbidden commands, forbidden binaries, forbidden substrings, forbidden regex patterns. When enabled, a command matching any layer is rejected before the approval prompt — it never reaches the user for consideration.
-- **Auto-Approve — SKIP-APPROVAL LIST.** When enabled, commands whose base verb appears in `auto_approved_commands` bypass the human approval prompt (the human has rubber-stamped them in advance as benign). Auto-approve is **independent** of whitelisting: it does not widen the whitelist and does not bypass the blacklist or hard-coded forbidden patterns. A command must still pass every L1 hard gate before auto-approve can apply.
+- **Denylist (blacklist) — HARD BLOCK-LIST.** Blocks specific commands, binaries, substrings, and regex patterns across four enforcement layers. **This is enabled by default** as a recommended boundary for system safety. When enabled, a command matching any layer is rejected before the approval prompt — it never reaches the user for consideration.
+- **Auto-Approve — SKIP-APPROVAL LIST.** **This is enabled by default** to work in harmony with the built-in reputation staking system. When enabled, commands whose base verb appears in `auto_approved_commands` bypass the human approval prompt (the human has rubber-stamped them in advance as benign). This provides peak signal and peak efficiency by allowing a team of heterogeneous agent personas to stake their reputation on the command along with the built-in reputation engine. 
+
+Auto-approve is **independent** of whitelisting: it does not widen the whitelist and does not bypass the blacklist or hard-coded forbidden patterns. A command must still pass every L1 hard gate before auto-approve can apply.
 
 #### Configuration
 
@@ -758,9 +760,9 @@ Command validation is configured per-user via the `command_validation` field in 
 ```
 
 - `enable_whitelisting` (bool, default: `false`) — When enabled, only commands in the whitelist are permitted (hard allow-list).
-- `enable_blacklisting` (bool, default: `false`) — When enabled, commands matching blacklist patterns are blocked (hard block-list).
+- `enable_blacklisting` (bool, default: `true`) — When enabled, commands matching blacklist patterns are blocked (hard block-list). Recommended for system safety.
 - `whitelisted_commands` (string, default: `""`) — Optional comma-separated list of allowed base commands (e.g. `uptime,df,free`).
-- `enable_auto_approve` (bool, default: `false`) — When enabled, commands whose base verb is in `auto_approved_commands` skip the human approval prompt. Independent of whitelisting; does **not** widen the whitelist and does **not** bypass the blacklist or hard-coded forbidden patterns.
+- `enable_auto_approve` (bool, default: `true`) — When enabled, commands whose base verb is in `auto_approved_commands` skip the human approval prompt. Works in harmony with reputation staking for peak efficiency.
 - `auto_approved_commands` (string, default: `""`) — Comma-separated list of base commands the human has rubber-stamped as benign (e.g. `uptime,df,free`). Only consulted when `enable_auto_approve` is `true`.
 
 **Whitelist Mode Semantics:**

--- a/docs/components/g8ee.md
+++ b/docs/components/g8ee.md
@@ -571,8 +571,8 @@ g8ee implements an **MCP Client Adapter** that translates outbound tool calls in
 | Policy | Setting | JSON Config | Semantics | Where enforced |
 |--------|---------|-------------|-----------|----------------|
 | Whitelist (hard allow-list) | `enable_whitelisting` + `whitelisted_commands` | `config/whitelist.json` (`enabled` field) | Only listed commands may run at all. Non-listed commands are rejected at L1 safety validation. | `app/utils/safety.py::validate_command_safety` |
-| Blacklist (hard block-list) | `enable_blacklisting` | `config/blacklist.json` (`enabled` field) | Listed commands/patterns are rejected at L1 safety validation. | `app/utils/safety.py::validate_command_safety` |
-| Auto-approve (skip-approval list) | `enable_auto_approve` + `config/auto_approved.json` (platform default) + `auto_approved_commands` (CSV override) | `config/auto_approved.json` (`enabled` field) | Listed base verbs bypass the human approval prompt. The JSON file ships platform-default benign verbs (`uptime`, `df`, `free`, …) loaded by `CommandAutoApprovedValidator`; the CSV setting unions per-user extras. Does NOT widen the whitelist and does NOT bypass the blacklist or hard-coded forbidden patterns. | `OperatorCommandService.execute_command_internal` |
+| Blacklist (hard block-list) | `enable_blacklisting` | `config/blacklist.json` (`enabled` field) | Listed commands/patterns are rejected at L1 safety validation. **Enabled by default** as a recommended safety boundary. | `app/utils/safety.py::validate_command_safety` |
+| Auto-approve (skip-approval list) | `enable_auto_approve` + `config/auto_approved.json` (platform default) + `auto_approved_commands` (CSV override) | `config/auto_approved.json` (`enabled` field) | Listed base verbs bypass the human approval prompt. **Enabled by default** to work in harmony with reputation staking (agent personas + built-in engine) for peak signal and efficiency. | `OperatorCommandService.execute_command_internal` |
 
 **JSON `enabled` field semantics:** Each JSON config file has an `enabled` boolean field (defaults to `true`). When `enabled: false`, the validator loads an empty index regardless of the entries in the file — this is a file-level kill switch that allows platform operators to neutralize the entire JSON file without touching per-request settings. Enforcement requires **both** the JSON `enabled` field and the corresponding per-request setting to be `true`.
 
@@ -1090,8 +1090,9 @@ The `agent_tool_loop.py` extracts these constraints from `tool_executor._user_se
 | Key | Default | Purpose |
 |-----|---------|---------|
 | `enable_whitelisting` | `false` | Restrict commands to an allowlist |
-| `enable_blacklisting` | `false` | Block commands matching a denylist |
+| `enable_blacklisting` | `true` | Block commands matching a denylist. Recommended for system safety. |
 | `whitelisted_commands` | — | CSV string of allowed commands (overrides default whitelist) |
+| `enable_auto_approve` | `true` | Skip approval for rubber-stamped commands. Works in harmony with reputation staking. |
 
 **Whitelist Mode Semantics:**
 - **JSON mode (default):** When `whitelisted_commands` is empty, the system uses a rich JSON whitelist (`config/whitelist.json`) with per-command `safe_options` and `validation` patterns.


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes introduced by this PR -->

Default operating mode is default blacklist and auto-approve lists enabled.

These boundaries + strictly forbidden patterns + reputation staking incentives to generate the perfect command = minimal click fatigue

This PR include a fix for interrogation, which was broken... and is still being improved.

## Engineering Commitment Checklist
- [x] User Intent is the Guiding Principle: Human control is maintained.
- [x] Human Agency is the Governance Model: AI proposes, human approves.
- [x] Security and Privacy as Bedrock: Changes pass the Security Review Checklist.
- [x] No Tech Debt: No `ensure*()`, `getOrCreate*()`, `JSON.stringify` as type coercion, `Any` in signatures, or `map[string]interface{}`.
- [x] Data Sovereignty: Stateless relay principles followed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code quality improvement, no logic changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [x] I have reproduced the bug (if applicable) with a test before fixing it.
- [x] I have added/updated tests to cover the changes.
- [x] All tests pass locally using `./g8e test <component>`.

## Related Documentation
- [x] I have reviewed and updated relevant documentation in `docs/` as necessary.
