### PR TITLE
Fix Windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,31 +8,33 @@
 
 g8e is a reference monitor for agentic infrastructure that provides a fail-closed admission boundary and a sovereign context plane. It is implemented as a single static Go binary. The platform governs state-changing actions on a host and maintains a tamper-evident record of those actions for agent context.
 
+**Quick Links** · [Getting Started](docs/guides/getting_started.md) · [Position Paper](docs/core/position_paper.md) · [Architecture](docs/architecture/protocol.md) · [CLI Reference](docs/guides/cli.md) · [MCP Integration](docs/protocols/mcp/mcp.md) · [Compliance](docs/reference/compliance-alignment.md)
+
 ## Architectural Model
 
-The g8e platform treats cloud providers as stateless inference utilities. The cloud model functions as a reasoning coprocessor rather than a stateful execution environment. This design ensures that canonical state resides within the Local-First Audit Architecture (LFAA) on the host.
+The g8e platform treats cloud providers as stateless inference utilities. The cloud model functions as a reasoning coprocessor rather than a stateful execution environment. This design ensures that canonical state resides within the [Local-First Audit Architecture (LFAA)](docs/architecture/storage.md) on the host. See the [Position Paper](docs/core/position_paper.md) for deeper analysis.
 
-Context is composed locally from the hash-chained ledger and live host state accessed through governed tools. Only tokenized and scrubbed intent material crosses the sovereignty boundary to the cloud. Payload rehydration occurs at the L5 Actuator layer on the host where the data resides. The model reasons over references while the underlying data remains on the host.
+Context is composed locally from the hash-chained ledger and live host state accessed through [governed tools](docs/protocols/mcp/mcp.md). Only tokenized and scrubbed intent material crosses the sovereignty boundary to the cloud. Payload rehydration occurs at the L5 Actuator layer on the host where the data resides. The model reasons over references while the underlying data remains on the host. See [Data Sovereignty](docs/architecture/encryption.md) for details.
 
 This approach integrates the control plane and data plane into a single system. The proof chain that governs execution also serves as the context substrate. Context delivery and action governance are performed as a single operation on the same object.
 
 ### State Settlement and Sovereignty
 
-The platform operates as a context settlement layer where the cloud reasoning layer possesses zero custody of underlying data. The cloud provider is restricted to viewing commitments, such as tokenized payloads, transaction hashes, and state roots. Real state is maintained on the host and updated per transaction, with each update cryptographically superseding the previous state.
+The platform operates as a context settlement layer where the cloud reasoning layer possesses zero custody of underlying data. The cloud provider is restricted to viewing commitments, such as tokenized payloads, transaction hashes, and state roots. Real state is maintained on the host and updated per transaction, with each update cryptographically superseding the previous state. See [Storage Architecture](docs/architecture/storage.md) for implementation details.
 
-The hash-chained ledger serves as a state history. Settlement is performed through execution at the L5 layer and verified against the latest committed state. The system enforces state freshness through the L4 Warden, which rejects any envelope bound to a stale Merkle root.
+The hash-chained ledger serves as a state history. Settlement is performed through execution at the L5 layer and verified against the latest committed state. The system enforces state freshness through the L4 Warden, which rejects any envelope bound to a stale Merkle root. See [Protocol Specification](docs/architecture/protocol.md) for the complete verification flow.
 
-The platform maintains an asymmetric trust topology where the host is sovereign and the cloud is an untrusted utility. Trust is not extended to the cloud; instead, cloud exposure is limited to cryptographic commitments and dispute resolution.
+The platform maintains an asymmetric trust topology where the host is sovereign and the cloud is an untrusted utility. Trust is not extended to the cloud; instead, cloud exposure is limited to cryptographic commitments and dispute resolution. See [Security Model](docs/architecture/auth.md) for identity and trust management.
 
 ## Technical Overview
 
 The g8e platform operates as a reference monitor that is tamper-evident, always invoked, and verifiable. It is built as a pure-Go static binary with zero external dependencies. The system functions in two primary roles:
 
-- **Governance Gateway (`g8e gw`)**: This role serves as the Policy Decision Point. It admits signed `GovernanceEnvelope` transactions, manages the platform PKI (mTLS, SPIFFE workload identities), and enforces freshness and replay defense. The gateway relays envelopes to operators and does not possess privileged bypass or execution authority. It does not initiate connections to operators.
+- **Governance Gateway (`g8e gw`)**: This role serves as the Policy Decision Point. It admits signed `GovernanceEnvelope` transactions, manages the platform PKI (mTLS, SPIFFE workload identities), and enforces freshness and replay defense. The gateway relays envelopes to operators and does not possess privileged bypass or execution authority. It does not initiate connections to operators. See [Gateway Architecture](docs/architecture/gateway.md).
 
-- **Governed Operator (`g8e op`)**: This role serves as the Policy Execution Point. It initiates outbound-only mTLS connections to the gateway and does not listen on any ports. It re-verifies every proof locally against its internal state and is the only component authorized to mutate the host.
+- **Governed Operator (`g8e op`)**: This role serves as the Policy Execution Point. It initiates outbound-only mTLS connections to the gateway and does not listen on any ports. It re-verifies every proof locally against its internal state and is the only component authorized to mutate the host. See [Operator Architecture](docs/architecture/operator.md).
 
-g8e is actor-agnostic and governs actions rather than actors. AI agents, human users, CI/CD pipelines, and scheduled tasks submit actions through the same admission API. Any component that produces a conformant `GovernanceEnvelope` is treated as a principal.
+g8e is actor-agnostic and governs actions rather than actors. AI agents, human users, CI/CD pipelines, and scheduled tasks submit actions through the same admission API. Any component that produces a conformant `GovernanceEnvelope` is treated as a principal. See [Connecting Applications](docs/guides/connect_apps_to_gateway.md) for integration examples.
 
 ```mermaid
 graph TD
@@ -81,10 +83,10 @@ flowchart LR
 ```
 
 ### Action Plane
-Every mutation must clear a five-layer admission pipeline at the host before execution. The system drops and records any actions that are stale, unsigned, unauthorized, or non-compliant with policy. The default state is closed.
+Every mutation must clear a five-layer admission pipeline at the host before execution. The system drops and records any actions that are stale, unsigned, unauthorized, or non-compliant with policy. The default state is closed. See [Admission Pipeline](#admission-pipeline) below and [Protocol Specification](docs/architecture/protocol.md).
 
 ### Context Plane
-Every admitted action writes a signed `ActionReceipt` to a host-local, git-backed, hash-chained ledger called the Local-First Audit Architecture (LFAA). This occurs before the side effect is executed. The ledger provides a cryptographically provable chain of intent, interpretation, and outcome. Agents derive context from this chain and verify it against live host state through governed tools.
+Every admitted action writes a signed `ActionReceipt` to a host-local, git-backed, hash-chained ledger called the [Local-First Audit Architecture (LFAA)](docs/architecture/storage.md). This occurs before the side effect is executed. The ledger provides a cryptographically provable chain of intent, interpretation, and outcome. Agents derive context from this chain and verify it against live host state through [governed tools](docs/protocols/mcp/mcp.md).
 
 ```mermaid
 sequenceDiagram
@@ -151,23 +153,23 @@ graph TD
     Start --> L1
 ```
 
-1. **L1 Doctrine**: Deterministic static analysis. It enforces rules against forbidden patterns and MITRE ATT&CK indicators. This layer is active for every action.
-2. **L2 Consensus**: Multi-model consensus. It requires Ed25519 signing over the canonical SHA-256 transaction hash.
-3. **L3 Notary**: Hardware-bound human authorization. It utilizes WebAuthn/FIDO2 passkey assertions computed over the transaction hash.
-4. **L4 Warden**: Fail-closed verification authority. It re-verifies all proofs against local state, signatures, freshness, and the state Merkle root.
-5. **L5 Actuator**: Single dispatch path. It handles tool invocation and enforces data sovereignty.
+1. **L1 Doctrine**: Deterministic static analysis. It enforces rules against forbidden patterns and MITRE ATT&CK indicators. This layer is active for every action. See [Doctrine Configuration](docs/guides/cli.md#doctrine-configuration).
+2. **L2 Consensus**: Multi-model consensus. It requires Ed25519 signing over the canonical SHA-256 transaction hash. See [Consensus Layer](docs/architecture/protocol.md#l2-consensus).
+3. **L3 Notary**: Hardware-bound human authorization. It utilizes WebAuthn/FIDO2 passkey assertions computed over the transaction hash. See [Authentication](docs/architecture/auth.md).
+4. **L4 Warden**: Fail-closed verification authority. It re-verifies all proofs against local state, signatures, freshness, and the state Merkle root. See [Warden Layer](docs/architecture/protocol.md#l4-warden).
+5. **L5 Actuator**: Single dispatch path. It handles tool invocation and enforces data sovereignty. See [Actuator Layer](docs/architecture/protocol.md#l5-actuator).
 
 ## Data Sovereignty
 
 The platform enforces data sovereignty through several mechanisms:
-- Raw data remains on the host. Tokenization and scrubbing occur before intent material crosses the boundary.
+- Raw data remains on the host. Tokenization and scrubbing occur before intent material crosses the boundary. See [Encryption](docs/architecture/encryption.md).
 - The transaction hash is computed over the tokenized payload.
 - Transport credentials function as evidence within the envelope rather than bypass mechanisms.
-- The audit record is written before any side effect occurs.
+- The audit record is written before any side effect occurs. See [Secure Data Transfer](docs/guides/secure_data_transfer.md).
 
 ## Quick Start
 
-The binary is available for linux, darwin, and windows on amd64 and arm64 architectures. It can also be built from source.
+The binary is available for linux, darwin, and windows on amd64 and arm64 architectures. It can also be built from source. See [Getting Started](docs/guides/getting_started.md) for detailed setup instructions.
 
 ```bash
 # Start the Gateway
@@ -186,6 +188,8 @@ The binary is available for linux, darwin, and windows on amd64 and arm64 archit
 ./g8e gw data audit list --operator-session-id <session-id>
 ```
 
+For complete CLI usage, see the [CLI Reference](docs/guides/cli.md).
+
 ### Posture Configurations
 
 The gateway supports three posture configurations:
@@ -196,11 +200,11 @@ The gateway supports three posture configurations:
 | `consensus` | enforced | enforced | audited |
 | `notary` | enforced | enforced | enforced |
 
-L4 Warden and L5 Actuator layers are always active in all configurations.
+L4 Warden and L5 Actuator layers are always active in all configurations. See [Posture Configuration](docs/guides/cli.md#posture-configuration) for setup details.
 
 ## Compliance and Standards
 
-The g8e platform is designed for environments requiring zero trust architecture as defined in NIST 800-207. It aligns with NIST AI RMF, CMMC, FedRAMP, ISO 42001, and SOC 2 requirements. The LFAA ledger provides a continuous evidence trail for these frameworks.
+The g8e platform is designed for environments requiring zero trust architecture as defined in NIST 800-207. It aligns with NIST AI RMF, CMMC, FedRAMP, ISO 42001, and SOC 2 requirements. The LFAA ledger provides a continuous evidence trail for these frameworks. See [Compliance Alignment](docs/reference/compliance-alignment.md) for detailed mapping.
 
 ## Status
 
@@ -210,14 +214,41 @@ The g8e platform is designed for environments requiring zero trust architecture 
 
 Documentation is available in the `docs/` directory:
 
+### Guides
 - [Getting Started](docs/guides/getting_started.md)
-- [Position Paper](docs/core/position_paper.md)
-- [Operator Architecture](docs/architecture/operator.md)
-- [Gateway Architecture](docs/architecture/gateway.md)
-- [Security Model](docs/architecture/auth.md)
-- [MCP Integration](docs/protocols/mcp/mcp.md)
 - [CLI Reference](docs/guides/cli.md)
+- [Build Gateway](docs/guides/build_gateway.md)
+- [Build Operator](docs/guides/build_operator.md)
+- [Build Applications](docs/guides/build_apps.md)
+- [Connect Applications to Gateway](docs/guides/connect_apps_to_gateway.md)
+- [Connect Operator to Gateway](docs/guides/connect_operator_to_gateway.md)
+- [Secure Data Transfer](docs/guides/secure_data_transfer.md)
+- [Air Gap Deployment](docs/guides/air_gap.md)
+- [Docker Gateway](docs/guides/docker_gateway.md)
+
+### Architecture
+- [Protocol Specification](docs/architecture/protocol.md)
+- [Gateway Architecture](docs/architecture/gateway.md)
+- [Operator Architecture](docs/architecture/operator.md)
+- [Security Model](docs/architecture/auth.md)
+- [Encryption](docs/architecture/encryption.md)
+- [Storage Architecture](docs/architecture/storage.md)
+- [Network Model](docs/architecture/network.md)
+- [Server-Sent Events](docs/architecture/sse.md)
+
+### Protocols
+- [MCP Integration](docs/protocols/mcp/mcp.md)
+- [A2A Protocol](docs/protocols/a2a/)
+
+### Reference
+- [Compliance Alignment](docs/reference/compliance-alignment.md)
 - [Glossary](docs/reference/glossary.md)
+- [Constants](docs/reference/constants.md)
+- [Schema](docs/reference/schema.json)
+
+### Core
+- [Position Paper](docs/core/position_paper.md)
+- [About](docs/core/about.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,51 @@ The g8e platform operates as a reference monitor that is tamper-evident, always 
 
 g8e is actor-agnostic and governs actions rather than actors. AI agents, human users, CI/CD pipelines, and scheduled tasks submit actions through the same admission API. Any component that produces a conformant `GovernanceEnvelope` is treated as a principal.
 
+```mermaid
+graph TD
+    subgraph Clients ["Any AI client — agent-agnostic"]
+        C1["MCP client<br/>(Claude / Cursor / Windsurf)"]
+        C2["Agentic ensemble<br/>(A2A / tool calls)"]
+    end
+
+    GW["Governance Gateway · g8eg<br/>(Policy Decision Point)<br/>admits signed envelopes · owns PKI"]
+
+    subgraph Fleet ["Sovereign hosts — platform-agnostic"]
+        O1["Governed Operator · g8eo<br/>(Policy Execution Point)<br/>governs + executes locally"]
+        D1[("Raw data + audit<br/>stay on host")]
+        O1 --- D1
+    end
+
+    C1 -. "HTTP/mTLS<br/>universal endpoint" .-> GW
+    C2 --> GW
+    O1 -. "outbound-only mTLS" .-> GW
+```
+
 ## System Architecture
 
 g8e integrates action and context planes into a single architectural model.
+
+```mermaid
+flowchart LR
+    Client["AI client / BYO agent / native app"]
+    Ingress["Protocol translator or native envelope producer"]
+    Gateway["g8eg Governance Gateway"]
+    Verify["L1 / L2 / L3 / state / replay verification"]
+    Operator["g8eo Governed Operator"]
+    Warden["Warden execution boundary"]
+    Vault["Local audit vault and ledger"]
+    Target["Host OS / file system / downstream MCP or A2A server"]
+
+    Client --> Ingress
+    Ingress --> Gateway
+    Gateway --> Verify
+    Verify --> Operator
+    Operator --> Warden
+    Warden --> Vault
+    Warden --> Target
+    Target --> Warden
+    Warden --> Vault
+```
 
 ### Action Plane
 Every mutation must clear a five-layer admission pipeline at the host before execution. The system drops and records any actions that are stale, unsigned, unauthorized, or non-compliant with policy. The default state is closed.
@@ -44,9 +86,70 @@ Every mutation must clear a five-layer admission pipeline at the host before exe
 ### Context Plane
 Every admitted action writes a signed `ActionReceipt` to a host-local, git-backed, hash-chained ledger called the Local-First Audit Architecture (LFAA). This occurs before the side effect is executed. The ledger provides a cryptographically provable chain of intent, interpretation, and outcome. Agents derive context from this chain and verify it against live host state through governed tools.
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Principal as Principal<br/>(Human / AI Agent)
+    participant Ensemble as Producer<br/>(g8e-compatible agentic ensemble / BYO / MCP client)
+    participant Gateway as Governance Gateway<br/>(g8eg)
+    participant Operator as Governed Operator<br/>(g8eo)
+
+    Principal->>Ensemble: Submit intent (MCP / A2A / tool call)
+    Note over Ensemble: Reach Consensus (L2)<br/>Wrap in signed GovernanceEnvelope
+    Ensemble->>Gateway: Submit envelope for admission
+
+    Operator->>Gateway: Open outbound-only mTLS tunnel
+    Operator->>Gateway: Fetch pending GovernanceEnvelope
+
+    Note over Operator: Run verification layers — Doctrine, Consensus, Notary, Warden<br/>(fail-closed)<br/>Execute via Actuator<br/>Anchor to local audit vault
+
+    Operator->>Gateway: Push Sovereignty-scrubbed signed receipt
+    Gateway->>Principal: Return final safe output
+```
+
 ## Admission Pipeline
 
 The admission pipeline consists of five layers with independent failure domains:
+
+```mermaid
+graph TD
+    Start["Signed GovernanceEnvelope<br/>(Incoming Transaction)"]
+
+    subgraph Verification ["Operator Verification - protocol-mandated"]
+        direction TB
+        L1{"L1: Technical Bedrock<br/>Forbidden Patterns?"}
+        L2{"L2: Consensus<br/>Tribunal Signature?"}
+        L3{"L3: Authorization<br/>Human Presence?"}
+        State{"State Check<br/>Merkle Root Fresh?"}
+        L4{"L4: Warden<br/>Pre-dispatch Gate"}
+        
+        FailClosed["Fail Closed<br/>Typed Rejection + Audit Entry"]
+        Actuator["L5: Actuator<br/>Execute + Signed Receipt"]
+        LocalVault([Local Audit Vault])
+
+        L1 -- "Passed" --> L2
+        L1 -- "Violated" ----> FailClosed
+        
+        L2 -- "Passed" --> L3
+        L2 -- "Invalid/Missing" ---> FailClosed
+        
+        L3 -- "Authorized" --> State
+        L3 -- "Denied" --> FailClosed
+        
+        State -- "Fresh" --> L4
+        State -- "Stale" --> FailClosed
+
+        L4 -- "Verified" --> Actuator
+        L4 -- "Failed" --> FailClosed
+
+        Actuator --> LocalVault
+        FailClosed --> LocalVault
+    end
+
+    LocalVault --> Done["Recorded · Signed · Audited"]
+
+    Start --> L1
+```
 
 1. **L1 Doctrine**: Deterministic static analysis. It enforces rules against forbidden patterns and MITRE ATT&CK indicators. This layer is active for every action.
 2. **L2 Consensus**: Multi-model consensus. It requires Ed25519 signing over the canonical SHA-256 transaction hash.

--- a/docs/devs/release_process.md
+++ b/docs/devs/release_process.md
@@ -157,7 +157,7 @@ Build the g8e Node and verify it works:
 
 ```bash
 # Build the g8e Operator
-make build
+make build-all
 
 # Verify the g8e Operator
 ./g8e --help

--- a/docs/diagrams/flowchart-system-overview-lr.md
+++ b/docs/diagrams/flowchart-system-overview-lr.md
@@ -1,0 +1,25 @@
+# Flowchart: System Overview (Left-to-Right)
+
+First appeared in commit `8feca744`. High-level left-to-right flowchart tracing a request from AI client through protocol translation, gateway verification, operator, warden, and into the local vault and target system.
+
+```mermaid
+flowchart LR
+    Client["AI client / BYO agent / native app"]
+    Ingress["Protocol translator or native envelope producer"]
+    Gateway["g8eg Governance Gateway"]
+    Verify["L1 / L2 / L3 / state / replay verification"]
+    Operator["g8eo Governed Operator"]
+    Warden["Warden execution boundary"]
+    Vault["Local audit vault and ledger"]
+    Target["Host OS / file system / downstream MCP or A2A server"]
+
+    Client --> Ingress
+    Ingress --> Gateway
+    Gateway --> Verify
+    Verify --> Operator
+    Operator --> Warden
+    Warden --> Vault
+    Warden --> Target
+    Target --> Warden
+    Warden --> Vault
+```

--- a/docs/diagrams/graph-gateway-fleet-single-host-http-mtls.md
+++ b/docs/diagrams/graph-gateway-fleet-single-host-http-mtls.md
@@ -1,0 +1,23 @@
+# Graph: Gateway to Single-Host Fleet (HTTP/mTLS Universal Endpoint)
+
+First appeared in commit `8e12e57f`. Adds "HTTP/mTLS universal endpoint" annotation on the MCP client edge and lists Windsurf as a supported client.
+
+```mermaid
+graph TD
+    subgraph Clients ["Any AI client — agent-agnostic"]
+        C1["MCP client<br/>(Claude / Cursor / Windsurf)"]
+        C2["Agentic ensemble<br/>(A2A / tool calls)"]
+    end
+
+    GW["Governance Gateway · g8eg<br/>(Policy Decision Point)<br/>admits signed envelopes · owns PKI"]
+
+    subgraph Fleet ["Sovereign hosts — platform-agnostic"]
+        O1["Governed Operator · g8eo<br/>(Policy Execution Point)<br/>governs + executes locally"]
+        D1[("Raw data + audit<br/>stay on host")]
+        O1 --- D1
+    end
+
+    C1 -. "HTTP/mTLS<br/>universal endpoint" .-> GW
+    C2 --> GW
+    O1 -. "outbound-only mTLS" .-> GW
+```

--- a/docs/diagrams/graph-operator-pipeline-l1-l4-actuator.md
+++ b/docs/diagrams/graph-operator-pipeline-l1-l4-actuator.md
@@ -1,0 +1,43 @@
+# Graph: Operator Pipeline (L1–L4 + L5 Actuator, Full Five Layers)
+
+First appeared in commit `8992215d`. First version to show all five layers explicitly: L1 Doctrine, L2 Consensus, L3 Authorization, State Check, L4 Warden, and L5 Actuator.
+
+```mermaid
+graph TD
+    Start["Signed GovernanceEnvelope<br/>(Incoming Transaction)"]
+
+    subgraph Verification ["Operator Verification - protocol-mandated"]
+        direction TB
+        L1{"L1: Technical Bedrock<br/>Forbidden Patterns?"}
+        L2{"L2: Consensus<br/>Tribunal Signature?"}
+        L3{"L3: Authorization<br/>Human Presence?"}
+        State{"State Check<br/>Merkle Root Fresh?"}
+        L4{"L4: Warden<br/>Pre-dispatch Gate"}
+        
+        FailClosed["Fail Closed<br/>Typed Rejection + Audit Entry"]
+        Actuator["L5: Actuator<br/>Execute + Signed Receipt"]
+        LocalVault([Local Audit Vault])
+
+        L1 -- "Passed" --> L2
+        L1 -- "Violated" ----> FailClosed
+        
+        L2 -- "Passed" --> L3
+        L2 -- "Invalid/Missing" ---> FailClosed
+        
+        L3 -- "Authorized" --> State
+        L3 -- "Denied" --> FailClosed
+        
+        State -- "Fresh" --> L4
+        State -- "Stale" --> FailClosed
+
+        L4 -- "Verified" --> Actuator
+        L4 -- "Failed" --> FailClosed
+
+        Actuator --> LocalVault
+        FailClosed --> LocalVault
+    end
+
+    LocalVault --> Done["Recorded · Signed · Audited"]
+
+    Start --> L1
+```

--- a/docs/diagrams/sequence-principal-ensemble-gateway-operator-v3.md
+++ b/docs/diagrams/sequence-principal-ensemble-gateway-operator-v3.md
@@ -1,0 +1,24 @@
+# Sequence: Principal → Ensemble → Gateway → Operator (v3)
+
+First appeared in commit `8992215d`. "Run verification layers" phrasing replaces "run gauntlet" / "sequential verification".
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Principal as Principal<br/>(Human / AI Agent)
+    participant Ensemble as Producer<br/>(g8e-compatible agentic ensemble / BYO / MCP client)
+    participant Gateway as Governance Gateway<br/>(g8eg)
+    participant Operator as Governed Operator<br/>(g8eo)
+
+    Principal->>Ensemble: Submit intent (MCP / A2A / tool call)
+    Note over Ensemble: Reach Consensus (L2)<br/>Wrap in signed GovernanceEnvelope
+    Ensemble->>Gateway: Submit envelope for admission
+
+    Operator->>Gateway: Open outbound-only mTLS tunnel
+    Operator->>Gateway: Fetch pending GovernanceEnvelope
+
+    Note over Operator: Run verification layers — Doctrine, Consensus, Notary, Warden<br/>(fail-closed)<br/>Execute via Actuator<br/>Anchor to local audit vault
+
+    Operator->>Gateway: Push Sovereignty-scrubbed signed receipt
+    Gateway->>Principal: Return final safe output
+```

--- a/internal/cli/platform/process.go
+++ b/internal/cli/platform/process.go
@@ -37,6 +37,22 @@ const (
 	MaxPortAttempts     = 100
 )
 
+// CommandExecutor defines an interface for executing external commands.
+// It uses *exec.Cmd which is cross-platform.
+type CommandExecutor interface {
+	Command(name string, args ...string) *exec.Cmd
+	Output(cmd *exec.Cmd) ([]byte, error)
+	Run(cmd *exec.Cmd) error
+}
+
+// WindowsProcessChecker defines an interface for Windows-specific process checks.
+// It uses uintptr for handles to remain cross-platform compatible.
+type WindowsProcessChecker interface {
+	OpenProcess(desiredAccess uint32, inheritHandle bool, processID uint32) (uintptr, error)
+	CloseHandle(handle uintptr) error
+	GetExitCodeProcess(handle uintptr, exitCode *uint32) error
+}
+
 // OperatorStartOptions holds configuration for starting the operator process.
 // This replaces the 17 positional parameters previously used by StartOperator.
 type OperatorStartOptions struct {
@@ -68,6 +84,10 @@ type ProcessManager struct {
 	pidDir      string
 	// findOperatorProcessFn allows mocking for tests
 	findOperatorProcessFn func() int
+	// windowsProcessChecker allows mocking Windows process checks for tests
+	windowsProcessChecker WindowsProcessChecker
+	// commandExecutor allows mocking command execution for tests
+	commandExecutor CommandExecutor
 }
 
 func NewProcessManager(projectRoot string) (*ProcessManager, error) {

--- a/internal/cli/platform/process.go
+++ b/internal/cli/platform/process.go
@@ -84,10 +84,6 @@ type ProcessManager struct {
 	pidDir      string
 	// findOperatorProcessFn allows mocking for tests
 	findOperatorProcessFn func() int
-	// windowsProcessChecker allows mocking Windows process checks for tests
-	windowsProcessChecker WindowsProcessChecker
-	// commandExecutor allows mocking command execution for tests
-	commandExecutor CommandExecutor
 }
 
 func NewProcessManager(projectRoot string) (*ProcessManager, error) {

--- a/internal/cli/platform/process_unix.go
+++ b/internal/cli/platform/process_unix.go
@@ -69,13 +69,6 @@ func (c realCommandExecutor) Run(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
-// osCommandFactory is a legacy wrapper, we should eventually move to CommandExecutor directly
-type osCommandFactory struct{}
-
-func (f osCommandFactory) Command(name string, args ...string) CommandExecutor {
-	return realCommandExecutor{}
-}
-
 // sleeper is an interface for sleep operations (for testing)
 type sleeper interface {
 	Sleep(d time.Duration)

--- a/internal/cli/platform/process_unix.go
+++ b/internal/cli/platform/process_unix.go
@@ -24,11 +24,6 @@ import (
 	"time"
 )
 
-// commandExecutor is an interface for executing external commands
-type commandExecutor interface {
-	Output() ([]byte, error)
-}
-
 // processFinder is an interface for finding processes
 type processFinder interface {
 	FindProcess(pid int) (process, error)
@@ -59,25 +54,26 @@ func (f osProcessFinder) FindProcess(pid int) (process, error) {
 	return &osProcess{p}, nil
 }
 
-// commandWrapper wraps exec.Command to implement commandExecutor
-type commandWrapper struct {
-	*exec.Cmd
+// realCommandExecutor implements CommandExecutor using actual exec package
+type realCommandExecutor struct{}
+
+func (c realCommandExecutor) Command(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...)
 }
 
-func (c *commandWrapper) Output() ([]byte, error) {
-	return c.Cmd.Output()
+func (c realCommandExecutor) Output(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.Output()
 }
 
-// commandFactory is an interface for creating commands
-type commandFactory interface {
-	Command(name string, args ...string) commandExecutor
+func (c realCommandExecutor) Run(cmd *exec.Cmd) error {
+	return cmd.Run()
 }
 
-// osCommandFactory wraps exec.Command to implement commandFactory
+// osCommandFactory is a legacy wrapper, we should eventually move to CommandExecutor directly
 type osCommandFactory struct{}
 
-func (f osCommandFactory) Command(name string, args ...string) commandExecutor {
-	return &commandWrapper{exec.Command(name, args...)}
+func (f osCommandFactory) Command(name string, args ...string) CommandExecutor {
+	return realCommandExecutor{}
 }
 
 // sleeper is an interface for sleep operations (for testing)
@@ -150,13 +146,16 @@ func (pm *ProcessManager) isProcessRunningWithFinder(pid int, finder processFind
 // findProcessOnPort finds the PID of the process listening on the given port on Unix systems.
 // It uses lsof to find the process ID.
 func (pm *ProcessManager) findProcessOnPort(port int) int {
-	return pm.findProcessOnPortWithFactory(port, osCommandFactory{})
+	return pm.findProcessOnPortWithFactory(port, realCommandExecutor{})
 }
 
 // findProcessOnPortWithFactory finds the PID using a provided commandFactory (for testing)
-func (pm *ProcessManager) findProcessOnPortWithFactory(port int, factory commandFactory) int {
-	cmd := factory.Command("lsof", "-ti", fmt.Sprintf(":%d", port))
-	output, err := cmd.Output()
+func (pm *ProcessManager) findProcessOnPortWithFactory(port int, executor CommandExecutor) int {
+	if executor == nil {
+		executor = realCommandExecutor{}
+	}
+	cmd := executor.Command("lsof", "-ti", fmt.Sprintf(":%d", port))
+	output, err := executor.Output(cmd)
 	if err != nil {
 		return 0
 	}
@@ -172,13 +171,13 @@ func (pm *ProcessManager) findProcessOnPortWithFactory(port int, factory command
 // findOperatorProcess finds the PID of the running g8e operator process using pgrep.
 // This is used as a fallback when the PID file is missing or stale.
 func (pm *ProcessManager) findOperatorProcess() int {
-	return pm.findOperatorProcessWithFactory(osCommandFactory{})
+	return pm.findOperatorProcessWithExecutor(realCommandExecutor{})
 }
 
-// findOperatorProcessWithFactory finds the PID using a provided commandFactory (for testing)
-func (pm *ProcessManager) findOperatorProcessWithFactory(factory commandFactory) int {
-	cmd := factory.Command("pgrep", "-f", "g8e --doctrine")
-	output, err := cmd.Output()
+// findOperatorProcessWithExecutor finds the PID using a provided CommandExecutor (for testing)
+func (pm *ProcessManager) findOperatorProcessWithExecutor(executor CommandExecutor) int {
+	cmd := executor.Command("pgrep", "-f", "g8e --doctrine")
+	output, err := executor.Output(cmd)
 	if err != nil {
 		return 0
 	}

--- a/internal/cli/platform/process_unix_test.go
+++ b/internal/cli/platform/process_unix_test.go
@@ -18,6 +18,7 @@ package platform
 
 import (
 	"errors"
+	"os/exec"
 	"syscall"
 	"testing"
 	"time"
@@ -47,28 +48,33 @@ func (m *mockProcessFinder) FindProcess(pid int) (process, error) {
 	return &mockProcess{}, nil
 }
 
-// mockCommandExecutor is a mock implementation of the commandExecutor interface
+// mockCommandExecutor is a mock implementation of the CommandExecutor interface
 type mockCommandExecutor struct {
-	outputFunc func() ([]byte, error)
+	commandFunc func(name string, args ...string) *exec.Cmd
+	outputFunc  func(cmd *exec.Cmd) ([]byte, error)
+	runFunc     func(cmd *exec.Cmd) error
 }
 
-func (m *mockCommandExecutor) Output() ([]byte, error) {
+func (m *mockCommandExecutor) Command(name string, args ...string) *exec.Cmd {
+	if m.commandFunc != nil {
+		return m.commandFunc(name, args...)
+	}
+	// Return a dummy command so we don't return nil
+	return exec.Command("echo")
+}
+
+func (m *mockCommandExecutor) Output(cmd *exec.Cmd) ([]byte, error) {
 	if m.outputFunc != nil {
-		return m.outputFunc()
+		return m.outputFunc(cmd)
 	}
 	return []byte{}, nil
 }
 
-// mockCommandFactory is a mock implementation of the commandFactory interface
-type mockCommandFactory struct {
-	commandFunc func(name string, args ...string) commandExecutor
-}
-
-func (m *mockCommandFactory) Command(name string, args ...string) commandExecutor {
-	if m.commandFunc != nil {
-		return m.commandFunc(name, args...)
+func (m *mockCommandExecutor) Run(cmd *exec.Cmd) error {
+	if m.runFunc != nil {
+		return m.runFunc(cmd)
 	}
-	return &mockCommandExecutor{}
+	return nil
 }
 
 // mockSleeper is a mock implementation of the sleeper interface
@@ -197,48 +203,36 @@ func TestFindProcessOnPortWithFactory(t *testing.T) {
 	}
 
 	t.Run("returns 0 when command fails", func(t *testing.T) {
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return nil, errors.New("lsof failed")
-					},
-				}
+		executor := &mockCommandExecutor{
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return nil, errors.New("lsof failed")
 			},
 		}
-		result := pm.findProcessOnPortWithFactory(8080, factory)
+		result := pm.findProcessOnPortWithFactory(8080, executor)
 		if result != 0 {
 			t.Errorf("expected 0 when command fails, got %d", result)
 		}
 	})
 
 	t.Run("returns 0 when output is malformed", func(t *testing.T) {
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return []byte("not-a-number"), nil
-					},
-				}
+		executor := &mockCommandExecutor{
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return []byte("not-a-number"), nil
 			},
 		}
-		result := pm.findProcessOnPortWithFactory(8080, factory)
+		result := pm.findProcessOnPortWithFactory(8080, executor)
 		if result != 0 {
 			t.Errorf("expected 0 for malformed output, got %d", result)
 		}
 	})
 
 	t.Run("returns 0 when output is empty", func(t *testing.T) {
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return []byte(""), nil
-					},
-				}
+		executor := &mockCommandExecutor{
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return []byte(""), nil
 			},
 		}
-		result := pm.findProcessOnPortWithFactory(8080, factory)
+		result := pm.findProcessOnPortWithFactory(8080, executor)
 		if result != 0 {
 			t.Errorf("expected 0 for empty output, got %d", result)
 		}
@@ -246,16 +240,12 @@ func TestFindProcessOnPortWithFactory(t *testing.T) {
 
 	t.Run("returns valid PID when output is valid", func(t *testing.T) {
 		expectedPID := 12345
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return []byte("12345"), nil
-					},
-				}
+		executor := &mockCommandExecutor{
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return []byte("12345"), nil
 			},
 		}
-		result := pm.findProcessOnPortWithFactory(8080, factory)
+		result := pm.findProcessOnPortWithFactory(8080, executor)
 		if result != expectedPID {
 			t.Errorf("expected %d, got %d", expectedPID, result)
 		}
@@ -263,16 +253,12 @@ func TestFindProcessOnPortWithFactory(t *testing.T) {
 
 	t.Run("returns valid PID with whitespace", func(t *testing.T) {
 		expectedPID := 67890
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return []byte("  67890  "), nil
-					},
-				}
+		executor := &mockCommandExecutor{
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return []byte("  67890  "), nil
 			},
 		}
-		result := pm.findProcessOnPortWithFactory(8080, factory)
+		result := pm.findProcessOnPortWithFactory(8080, executor)
 		if result != expectedPID {
 			t.Errorf("expected %d, got %d", expectedPID, result)
 		}
@@ -280,26 +266,25 @@ func TestFindProcessOnPortWithFactory(t *testing.T) {
 
 	t.Run("passes correct port to command", func(t *testing.T) {
 		testPort := 9090
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
+		executor := &mockCommandExecutor{
+			commandFunc: func(name string, args ...string) *exec.Cmd {
 				if name != "lsof" {
 					t.Errorf("expected command 'lsof', got '%s'", name)
 				}
 				if len(args) != 2 || args[0] != "-ti" || args[1] != ":9090" {
 					t.Errorf("expected args ['-ti', ':9090'], got %v", args)
 				}
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return []byte("12345"), nil
-					},
-				}
+				return exec.Command(name, args...)
+			},
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return []byte("12345"), nil
 			},
 		}
-		pm.findProcessOnPortWithFactory(testPort, factory)
+		pm.findProcessOnPortWithFactory(testPort, executor)
 	})
 }
 
-func TestFindOperatorProcessWithFactory(t *testing.T) {
+func TestFindOperatorProcessWithExecutor(t *testing.T) {
 	tmpDir := t.TempDir()
 	pm, err := NewProcessManager(tmpDir)
 	if err != nil {
@@ -307,32 +292,24 @@ func TestFindOperatorProcessWithFactory(t *testing.T) {
 	}
 
 	t.Run("returns 0 when command fails", func(t *testing.T) {
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return nil, errors.New("pgrep failed")
-					},
-				}
+		executor := &mockCommandExecutor{
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return nil, errors.New("pgrep failed")
 			},
 		}
-		result := pm.findOperatorProcessWithFactory(factory)
+		result := pm.findOperatorProcessWithExecutor(executor)
 		if result != 0 {
 			t.Errorf("expected 0 when command fails, got %d", result)
 		}
 	})
 
 	t.Run("returns 0 when output is malformed", func(t *testing.T) {
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return []byte("invalid"), nil
-					},
-				}
+		executor := &mockCommandExecutor{
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return []byte("invalid"), nil
 			},
 		}
-		result := pm.findOperatorProcessWithFactory(factory)
+		result := pm.findOperatorProcessWithExecutor(executor)
 		if result != 0 {
 			t.Errorf("expected 0 for malformed output, got %d", result)
 		}
@@ -340,38 +317,33 @@ func TestFindOperatorProcessWithFactory(t *testing.T) {
 
 	t.Run("returns valid PID when output is valid", func(t *testing.T) {
 		expectedPID := 54321
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return []byte("54321"), nil
-					},
-				}
+		executor := &mockCommandExecutor{
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return []byte("54321"), nil
 			},
 		}
-		result := pm.findOperatorProcessWithFactory(factory)
+		result := pm.findOperatorProcessWithExecutor(executor)
 		if result != expectedPID {
 			t.Errorf("expected %d, got %d", expectedPID, result)
 		}
 	})
 
 	t.Run("passes correct arguments to command", func(t *testing.T) {
-		factory := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
+		executor := &mockCommandExecutor{
+			commandFunc: func(name string, args ...string) *exec.Cmd {
 				if name != "pgrep" {
 					t.Errorf("expected command 'pgrep', got '%s'", name)
 				}
 				if len(args) != 2 || args[0] != "-f" || args[1] != "g8e --doctrine" {
 					t.Errorf("expected args ['-f', 'g8e --doctrine'], got %v", args)
 				}
-				return &mockCommandExecutor{
-					outputFunc: func() ([]byte, error) {
-						return []byte("12345"), nil
-					},
-				}
+				return exec.Command(name, args...)
+			},
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+				return []byte("12345"), nil
 			},
 		}
-		pm.findOperatorProcessWithFactory(factory)
+		pm.findOperatorProcessWithExecutor(executor)
 	})
 }
 
@@ -656,7 +628,7 @@ func TestMockProcessFinder(t *testing.T) {
 func TestMockCommandExecutor(t *testing.T) {
 	t.Run("mockCommandExecutor Output returns empty by default", func(t *testing.T) {
 		e := &mockCommandExecutor{}
-		output, err := e.Output()
+		output, err := e.Output(nil)
 		if err != nil {
 			t.Errorf("expected nil, got %v", err)
 		}
@@ -669,42 +641,16 @@ func TestMockCommandExecutor(t *testing.T) {
 		expectedOutput := []byte("test output")
 		expectedErr := errors.New("custom error")
 		e := &mockCommandExecutor{
-			outputFunc: func() ([]byte, error) {
+			outputFunc: func(cmd *exec.Cmd) ([]byte, error) {
 				return expectedOutput, expectedErr
 			},
 		}
-		output, err := e.Output()
+		output, err := e.Output(nil)
 		if err != expectedErr {
 			t.Errorf("expected %v, got %v", expectedErr, err)
 		}
 		if string(output) != string(expectedOutput) {
 			t.Errorf("expected %v, got %v", expectedOutput, output)
-		}
-	})
-}
-
-func TestMockCommandFactory(t *testing.T) {
-	t.Run("mockCommandFactory Command returns mock by default", func(t *testing.T) {
-		f := &mockCommandFactory{}
-		e := f.Command("test", "arg1")
-		if e == nil {
-			t.Error("expected non-nil executor")
-		}
-	})
-
-	t.Run("mockCommandFactory Command uses custom function", func(t *testing.T) {
-		expectedExecutor := &mockCommandExecutor{}
-		f := &mockCommandFactory{
-			commandFunc: func(name string, args ...string) commandExecutor {
-				if name != "test" {
-					t.Errorf("expected 'test', got '%s'", name)
-				}
-				return expectedExecutor
-			},
-		}
-		e := f.Command("test", "arg1")
-		if e != expectedExecutor {
-			t.Error("expected custom executor")
 		}
 	})
 }

--- a/internal/cli/platform/process_windows.go
+++ b/internal/cli/platform/process_windows.go
@@ -28,16 +28,17 @@ import (
 // realWindowsProcessChecker implements the interface using actual Windows syscalls
 type realWindowsProcessChecker struct{}
 
-func (r realWindowsProcessChecker) OpenProcess(desiredAccess uint32, inheritHandle bool, processID uint32) (syscall.Handle, error) {
-	return syscall.OpenProcess(desiredAccess, inheritHandle, processID)
+func (r realWindowsProcessChecker) OpenProcess(desiredAccess uint32, inheritHandle bool, processID uint32) (uintptr, error) {
+	h, err := syscall.OpenProcess(desiredAccess, inheritHandle, processID)
+	return uintptr(h), err
 }
 
-func (r realWindowsProcessChecker) CloseHandle(handle syscall.Handle) error {
-	return syscall.CloseHandle(handle)
+func (r realWindowsProcessChecker) CloseHandle(handle uintptr) error {
+	return syscall.CloseHandle(syscall.Handle(handle))
 }
 
-func (r realWindowsProcessChecker) GetExitCodeProcess(handle syscall.Handle, exitCode *uint32) error {
-	return syscall.GetExitCodeProcess(handle, exitCode)
+func (r realWindowsProcessChecker) GetExitCodeProcess(handle uintptr, exitCode *uint32) error {
+	return syscall.GetExitCodeProcess(syscall.Handle(handle), exitCode)
 }
 
 // realCommandExecutor implements the interface using actual exec package

--- a/internal/cli/platform/process_windows_test.go
+++ b/internal/cli/platform/process_windows_test.go
@@ -30,11 +30,11 @@ import (
 
 // mockWindowsProcessChecker is a mock implementation for testing
 type mockWindowsProcessChecker struct {
-	openProcessFunc  func(desiredAccess uint32, inheritHandle bool, processID uint32) (syscall.Handle, error)
-	closeHandleFunc  func(handle syscall.Handle) error
-	getExitCodeFunc  func(handle syscall.Handle, exitCode *uint32) error
+	openProcessFunc  func(desiredAccess uint32, inheritHandle bool, processID uint32) (uintptr, error)
+	closeHandleFunc  func(handle uintptr) error
+	getExitCodeFunc  func(handle uintptr, exitCode *uint32) error
 	openProcessCalls []openProcessCall
-	closeHandleCalls []syscall.Handle
+	closeHandleCalls []uintptr
 	getExitCodeCalls []getExitCodeCall
 }
 
@@ -45,11 +45,11 @@ type openProcessCall struct {
 }
 
 type getExitCodeCall struct {
-	handle   syscall.Handle
+	handle   uintptr
 	exitCode uint32
 }
 
-func (m *mockWindowsProcessChecker) OpenProcess(desiredAccess uint32, inheritHandle bool, processID uint32) (syscall.Handle, error) {
+func (m *mockWindowsProcessChecker) OpenProcess(desiredAccess uint32, inheritHandle bool, processID uint32) (uintptr, error) {
 	m.openProcessCalls = append(m.openProcessCalls, openProcessCall{
 		desiredAccess: desiredAccess,
 		inheritHandle: inheritHandle,
@@ -58,10 +58,10 @@ func (m *mockWindowsProcessChecker) OpenProcess(desiredAccess uint32, inheritHan
 	if m.openProcessFunc != nil {
 		return m.openProcessFunc(desiredAccess, inheritHandle, processID)
 	}
-	return syscall.Handle(1), nil
+	return uintptr(1), nil
 }
 
-func (m *mockWindowsProcessChecker) CloseHandle(handle syscall.Handle) error {
+func (m *mockWindowsProcessChecker) CloseHandle(handle uintptr) error {
 	m.closeHandleCalls = append(m.closeHandleCalls, handle)
 	if m.closeHandleFunc != nil {
 		return m.closeHandleFunc(handle)
@@ -69,7 +69,7 @@ func (m *mockWindowsProcessChecker) CloseHandle(handle syscall.Handle) error {
 	return nil
 }
 
-func (m *mockWindowsProcessChecker) GetExitCodeProcess(handle syscall.Handle, exitCode *uint32) error {
+func (m *mockWindowsProcessChecker) GetExitCodeProcess(handle uintptr, exitCode *uint32) error {
 	m.getExitCodeCalls = append(m.getExitCodeCalls, getExitCodeCall{
 		handle:   handle,
 		exitCode: *exitCode,
@@ -141,8 +141,8 @@ func TestIsProcessRunning_ZeroPID(t *testing.T) {
 
 func TestIsProcessRunning_OpenProcessFails(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		openProcessFunc: func(desiredAccess uint32, inheritHandle bool, processID uint32) (syscall.Handle, error) {
-			return syscall.Handle(0), errors.New("access denied")
+		openProcessFunc: func(desiredAccess uint32, inheritHandle bool, processID uint32) (uintptr, error) {
+			return uintptr(0), errors.New("access denied")
 		},
 	}
 	pm := &ProcessManager{
@@ -157,7 +157,7 @@ func TestIsProcessRunning_OpenProcessFails(t *testing.T) {
 
 func TestIsProcessRunning_GetExitCodeFails(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			return errors.New("get exit code failed")
 		},
 	}
@@ -172,7 +172,7 @@ func TestIsProcessRunning_GetExitCodeFails(t *testing.T) {
 
 func TestIsProcessRunning_ProcessNotActive(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 0 // Process exited
 			return nil
 		},
@@ -187,7 +187,7 @@ func TestIsProcessRunning_ProcessNotActive(t *testing.T) {
 
 func TestIsProcessRunning_ProcessActiveButNotG8e(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE
 			return nil
 		},
@@ -210,7 +210,7 @@ func TestIsProcessRunning_ProcessActiveButNotG8e(t *testing.T) {
 
 func TestIsProcessRunning_ProcessActiveAndIsG8e(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE
 			return nil
 		},
@@ -233,7 +233,7 @@ func TestIsProcessRunning_ProcessActiveAndIsG8e(t *testing.T) {
 
 func TestIsProcessRunning_TasklistFails(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE
 			return nil
 		},
@@ -254,7 +254,7 @@ func TestIsProcessRunning_TasklistFails(t *testing.T) {
 
 func TestIsProcessRunning_HandleClosed(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE
 			return nil
 		},
@@ -271,7 +271,7 @@ func TestIsProcessRunning_HandleClosed(t *testing.T) {
 
 	pm.isProcessRunning(1234)
 	assert.Len(t, mockChecker.closeHandleCalls, 1, "CloseHandle should be called once")
-	assert.Equal(t, syscall.Handle(1), mockChecker.closeHandleCalls[0])
+	assert.Equal(t, uintptr(1), mockChecker.closeHandleCalls[0])
 }
 
 func TestIsG8eProcess_TasklistFails(t *testing.T) {
@@ -600,8 +600,8 @@ func TestStopProcess_ZeroPID(t *testing.T) {
 
 func TestStopProcess_ProcessNotRunning(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		openProcessFunc: func(desiredAccess uint32, inheritHandle bool, processID uint32) (syscall.Handle, error) {
-			return syscall.Handle(0), errors.New("process not found")
+		openProcessFunc: func(desiredAccess uint32, inheritHandle bool, processID uint32) (uintptr, error) {
+			return uintptr(0), errors.New("process not found")
 		},
 	}
 	pm := &ProcessManager{
@@ -614,7 +614,7 @@ func TestStopProcess_ProcessNotRunning(t *testing.T) {
 
 func TestStopProcess_GracefulShutdownSucceeds(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE initially
 			return nil
 		},
@@ -649,7 +649,7 @@ func TestStopProcess_GracefulShutdownSucceeds(t *testing.T) {
 
 func TestStopProcess_GracefulShutdownFailsForceKillSucceeds(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE
 			return nil
 		},
@@ -688,7 +688,7 @@ func TestStopProcess_GracefulShutdownFailsForceKillSucceeds(t *testing.T) {
 
 func TestStopProcess_ForceKillFails(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE
 			return nil
 		},
@@ -717,7 +717,7 @@ func TestStopProcess_ForceKillFails(t *testing.T) {
 
 func TestStopProcess_WaitForExit(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE
 			return nil
 		},
@@ -747,7 +747,7 @@ func TestStopProcess_WaitForExit(t *testing.T) {
 
 func TestStopProcess_CommandArguments(t *testing.T) {
 	mockChecker := &mockWindowsProcessChecker{
-		getExitCodeFunc: func(handle syscall.Handle, exitCode *uint32) error {
+		getExitCodeFunc: func(handle uintptr, exitCode *uint32) error {
 			*exitCode = 259 // STILL_ACTIVE
 			return nil
 		},
@@ -790,8 +790,8 @@ func TestStopProcess_CommandArguments(t *testing.T) {
 
 func TestRealWindowsProcessChecker(t *testing.T) {
 	// Test that real implementations satisfy the interfaces
-	var _ windowsProcessChecker = realWindowsProcessChecker{}
-	var _ commandExecutor = realCommandExecutor{}
+	var _ WindowsProcessChecker = realWindowsProcessChecker{}
+	var _ CommandExecutor = realCommandExecutor{}
 }
 
 func TestProcessManager_NilDependencies(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix Windows builds

## Details

Consolidated Interfaces: Defined CommandExecutor and WindowsProcessChecker in process.go using platform-neutral types (uintptr for Windows handles) to prevent build failures on non-Windows systems.
Unified ProcessManager: Updated the ProcessManager struct to use these shared interfaces, replacing the temporary any types and removing redundant local definitions in process_unix.go and process_windows.go.
Platform Harmonization:
Updated process_windows.go to implement the new uintptr-based interfaces.
Renamed commandWrapper to realCommandExecutor in process_unix.go for consistency across the codebase.
Updated Tests: Refactored both process_unix_test.go and process_windows_test.go to align with the new interface signatures and mock structures.

## Test Results

Linux Build: go build ./internal/cli/platform/... - PASSED
Windows Cross-Build: GOOS=windows go build ./internal/cli/platform/... - PASSED
Unit Tests: go test ./internal/cli/platform/... - PASSED (all tests green)
