### PR TITLE
fix windows builds and update ci

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,3 +72,6 @@ jobs:
       - name: Integration Tests
         run: make test-integration
 
+      - name: Cross-Compile (Windows)
+        run: make build-windows
+

--- a/internal/services/execution/fs_list_windows.go
+++ b/internal/services/execution/fs_list_windows.go
@@ -66,7 +66,7 @@ func (s *FsListService) ExecuteFsList(ctx context.Context, req *models.FsListReq
 		Status:          operatorv1.ExecutionStatus_EXECUTION_STATUS_EXECUTING,
 		Entries:         []models.FsListEntry{},
 	}
-	result.StartTime = &startTime
+	result.StartTime = startTime
 
 	// Resolve path - default to operator's working directory when none is specified
 	path := req.Path

--- a/internal/services/governance/l1_doctrine_test.go
+++ b/internal/services/governance/l1_doctrine_test.go
@@ -1490,7 +1490,6 @@ func TestL1Doctrine_ValidateIntent_Pinning(t *testing.T) {
 }
 
 // FuzzAnalyzeMCPArguments fuzz tests the AnalyzeMCPArguments method
-// This is migrated from sentinel_input_fuzz_test.go
 func FuzzAnalyzeMCPArguments(f *testing.F) {
 	doctrine := NewL1Doctrine()
 


### PR DESCRIPTION
## Summary

fix windows builds and update ci

## Details

Windows builds are failing, should have been caught in ci

## Test Results
```
bob@dev:~/g8e (fix/windows-build-6-22) $ make build-windows
Building g8e for Windows...
Building windows/amd64 -> bin/g8e-windows-amd64.exe...
Building windows/arm64 -> bin/g8e-windows-arm64.exe...
Windows build complete. Binaries: bin/g8e-windows-*.exe
bob@dev:~/g8e (fix/windows-build-6-22) $ 

```